### PR TITLE
Add a geo location service to netflix media rule

### DIFF
--- a/Clash/Provider/Media/Netflix.yaml
+++ b/Clash/Provider/Media/Netflix.yaml
@@ -26,7 +26,8 @@ payload:
 
   - DOMAIN-SUFFIX,e13252.dscg.akamaiedge.net
   - DOMAIN-SUFFIX,h-netflix.online-metrix.net
-  - DOMAIN,geolocation.onetrust.com
+  - DOMAIN-SUFFIX,onetrust.com
+  - DOMAIN-SUFFIX,cookielaw.org
 
   - IP-CIDR,23.246.0.0/18,no-resolve
   - IP-CIDR,37.77.184.0/21,no-resolve

--- a/Clash/Provider/Media/Netflix.yaml
+++ b/Clash/Provider/Media/Netflix.yaml
@@ -26,6 +26,7 @@ payload:
 
   - DOMAIN-SUFFIX,e13252.dscg.akamaiedge.net
   - DOMAIN-SUFFIX,h-netflix.online-metrix.net
+  - DOMAIN,geolocation.onetrust.com
 
   - IP-CIDR,23.246.0.0/18,no-resolve
   - IP-CIDR,37.77.184.0/21,no-resolve

--- a/Surge/Surge 3/Provider/Media/Netflix.list
+++ b/Surge/Surge 3/Provider/Media/Netflix.list
@@ -25,7 +25,8 @@ DOMAIN-SUFFIX,nflxvideo.net
 
 DOMAIN,e13252.dscg.akamaiedge.net
 DOMAIN,h-netflix.online-metrix.net
-DOMAIN,geolocation.onetrust.com
+DOMAIN-SUFFIX,onetrust.com
+DOMAIN-SUFFIX,cookielaw.org
 
 IP-CIDR,23.246.0.0/18,no-resolve
 IP-CIDR,37.77.184.0/21,no-resolve

--- a/Surge/Surge 3/Provider/Media/Netflix.list
+++ b/Surge/Surge 3/Provider/Media/Netflix.list
@@ -25,6 +25,7 @@ DOMAIN-SUFFIX,nflxvideo.net
 
 DOMAIN,e13252.dscg.akamaiedge.net
 DOMAIN,h-netflix.online-metrix.net
+DOMAIN,geolocation.onetrust.com
 
 IP-CIDR,23.246.0.0/18,no-resolve
 IP-CIDR,37.77.184.0/21,no-resolve


### PR DESCRIPTION
The Netflix webpage version use a GET request to the domain to be added, in order to fetch geo location of visitors, and check if any proxy is in use.