### PR TITLE
Update Google FCM domains according to official docs

### DIFF
--- a/Clash/Provider/Google FCM.yaml
+++ b/Clash/Provider/Google FCM.yaml
@@ -1,5 +1,10 @@
 payload:
   # > Google FCM
+  # According to Firebase FAQ https://firebase.google.com/docs/cloud-messaging/concept-options#messaging-ports-and-your-firewall
+  - DOMAIN,mtalk.google.com
+  - DOMAIN,mtalk4.google.com
+  - DOMAIN,mtalk-staging.google.com,
+  - DOMAIN,mtalk-dev.google.com
   - DOMAIN,alt1-mtalk.google.com
   - DOMAIN,alt2-mtalk.google.com
   - DOMAIN,alt3-mtalk.google.com
@@ -8,7 +13,9 @@ payload:
   - DOMAIN,alt6-mtalk.google.com
   - DOMAIN,alt7-mtalk.google.com
   - DOMAIN,alt8-mtalk.google.com
-  - DOMAIN,mtalk.google.com
+  - DOMAIN,android.apis.google.com
+  - DOMAIN,device-provisioning.googleapis.com
+  - DOMAIN,firebaseinstallations.googleapis.com
   - IP-CIDR,64.233.177.188/32,no-resolve
   - IP-CIDR,64.233.186.188/32,no-resolve
   - IP-CIDR,64.233.187.188/32,no-resolve


### PR DESCRIPTION
Update Google FCM domains according to [Firebase Official docs](https://firebase.google.com/docs/cloud-messaging/concept-options#messaging-ports-and-your-firewall)

PS: Google FCM works well in mainland even without any proxys. The FCM domains, addresses, and DNS requests should be white listed to maintain ideal performance and preserve mobile device batteries. 