### PR TITLE
根据群友要求更新clash及surge关于ios26.1 在昨日基础上的AI规则

### DIFF
--- a/Clash/Provider/AI Suite.yaml
+++ b/Clash/Provider/AI Suite.yaml
@@ -108,15 +108,10 @@ payload:
   - DOMAIN-SUFFIX,apple-relay.apple.com
   - DOMAIN-SUFFIX,apple-relay.fastly-edge.com
   - DOMAIN-SUFFIX,apple-relay.cloudflare.com
-  - DOMAIN-SUFFIX,gateway.icloud.com
   - DOMAIN-SUFFIX,guzzoni.apple.com
   - DOMAIN-SUFFIX,cp4.cloudflare.com
   - DOMAIN-SUFFIX,gspe1-ssl.ls.apple.com
-  - DOMAIN-SUFFIX,apps.mzstatic.com
-  - DOMAIN-SUFFIX,amp-api.apps.apple.com
   - DOMAIN-SUFFIX,smoot.apple.com
-  - DOMAIN-SUFFIX,updates.cdn-apple.com
-  - DOMAIN-SUFFIX,apple-relay.mask.apple-dns.net
 
   # > Sora
   - DOMAIN-SUFFIX,sora.com

--- a/Clash/Provider/Special.yaml
+++ b/Clash/Provider/Special.yaml
@@ -12,6 +12,7 @@ payload:
   - DOMAIN,osxapps.itunes.apple.com
   - DOMAIN,supportdownload.apple.com
   - DOMAIN,swcdn.apple.com
+  - DOMAIN,updates-http.cdn-apple.com
 
   # > Epic
   - DOMAIN-KEYWORD,epicgames

--- a/Surge/Surge 3/Provider/AI Suite.list
+++ b/Surge/Surge 3/Provider/AI Suite.list
@@ -107,15 +107,10 @@ DOMAIN-SUFFIX,poe.com
 DOMAIN-SUFFIX,apple-relay.apple.com
 DOMAIN-SUFFIX,apple-relay.fastly-edge.com
 DOMAIN-SUFFIX,apple-relay.cloudflare.com
-DOMAIN-SUFFIX,gateway.icloud.com
 DOMAIN-SUFFIX,guzzoni.apple.com
 DOMAIN-SUFFIX,cp4.cloudflare.com
 DOMAIN-SUFFIX,gspe1-ssl.ls.apple.com
-DOMAIN-SUFFIX,apps.mzstatic.com
-DOMAIN-SUFFIX,amp-api.apps.apple.com
 DOMAIN-SUFFIX,smoot.apple.com
-DOMAIN-SUFFIX,updates.cdn-apple.com
-DOMAIN-SUFFIX,apple-relay.mask.apple-dns.net
 
 # > Sora
 DOMAIN-SUFFIX,sora.com

--- a/Surge/Surge 3/Provider/Special.list
+++ b/Surge/Surge 3/Provider/Special.list
@@ -11,6 +11,7 @@ DOMAIN,mvod.itunes.apple.com
 DOMAIN,osxapps.itunes.apple.com
 DOMAIN,supportdownload.apple.com
 DOMAIN,swcdn.apple.com
+DOMAIN,updates-http.cdn-apple.com
 
 # > Duet
 USER-AGENT,duet*


### PR DESCRIPTION
根据群里的需求精简了AI Suite里面的规则删除了DOMAIN,updates-http.cdn-apple.com并在Special里面重新添加了DOMAIN,updates-http.cdn-apple.com