### PR TITLE
feat: add rules for `claude.com`

### DIFF
--- a/Clash/Provider/AI Suite.yaml
+++ b/Clash/Provider/AI Suite.yaml
@@ -26,6 +26,7 @@ payload:
 
   # > Claude
   - DOMAIN-SUFFIX,anthropic.com
+  - DOMAIN-SUFFIX,claude.com
   - DOMAIN-SUFFIX,claude.ai
   - DOMAIN-SUFFIX,claudeusercontent.com
 


### PR DESCRIPTION
## Changes

- add `claude.com` to selector: AI Suite




refs: 

- https://docs.claude.com/
- https://www.anthropic.com/app-unavailable-in-region -> which will redirect to https://docs.claude.com/