### PR TITLE
Add company lookup domains to Domestic rules

### DIFF
--- a/Clash/Provider/Domestic.yaml
+++ b/Clash/Provider/Domestic.yaml
@@ -86,6 +86,7 @@ payload:
   - DOMAIN-SUFFIX,acfun.tv
   - DOMAIN-SUFFIX,adobesc.com
   - DOMAIN-SUFFIX,aiaa.org
+  - DOMAIN-SUFFIX,aiqicha.com
   - DOMAIN-SUFFIX,air-matters.com
   - DOMAIN-SUFFIX,air-matters.io
   - DOMAIN-SUFFIX,aixifan.com
@@ -215,10 +216,12 @@ payload:
   - DOMAIN-SUFFIX,pniao.com
   - DOMAIN-SUFFIX,privatehd.to
   - DOMAIN-SUFFIX,qbox.me
+  - DOMAIN-SUFFIX,qcc.com
   - DOMAIN-SUFFIX,qcloud.com
   - DOMAIN-SUFFIX,qdaily.com
   - DOMAIN-SUFFIX,qdmm.com
   - DOMAIN-SUFFIX,qhimg.com
+  - DOMAIN-SUFFIX,qichacha.com
   - DOMAIN-SUFFIX,qidian.com
   - DOMAIN-SUFFIX,qihucdn.com
   - DOMAIN-SUFFIX,qin.io

--- a/Egern/Provider/Domestic.yaml
+++ b/Egern/Provider/Domestic.yaml
@@ -68,6 +68,7 @@ domain_suffix_set:
   - acfun.tv
   - adobesc.com
   - aiaa.org
+  - aiqicha.com
   - air-matters.com
   - air-matters.io
   - aixifan.com
@@ -199,10 +200,12 @@ domain_suffix_set:
   - pniao.com
   - privatehd.to
   - qbox.me
+  - qcc.com
   - qcloud.com
   - qdaily.com
   - qdmm.com
   - qhimg.com
+  - qichacha.com
   - qidian.com
   - qihucdn.com
   - qin.io

--- a/Surge/Surge 3/Provider/Domestic.list
+++ b/Surge/Surge 3/Provider/Domestic.list
@@ -85,6 +85,7 @@ DOMAIN-SUFFIX,abercrombie.com
 DOMAIN-SUFFIX,acfun.tv
 DOMAIN-SUFFIX,adobesc.com
 DOMAIN-SUFFIX,aiaa.org
+DOMAIN-SUFFIX,aiqicha.com
 DOMAIN-SUFFIX,air-matters.com
 DOMAIN-SUFFIX,air-matters.io
 DOMAIN-SUFFIX,aixifan.com
@@ -214,10 +215,12 @@ DOMAIN-SUFFIX,pgyer.com
 DOMAIN-SUFFIX,pniao.com
 DOMAIN-SUFFIX,privatehd.to
 DOMAIN-SUFFIX,qbox.me
+DOMAIN-SUFFIX,qcc.com
 DOMAIN-SUFFIX,qcloud.com
 DOMAIN-SUFFIX,qdaily.com
 DOMAIN-SUFFIX,qdmm.com
 DOMAIN-SUFFIX,qhimg.com
+DOMAIN-SUFFIX,qichacha.com
 DOMAIN-SUFFIX,qidian.com
 DOMAIN-SUFFIX,qihucdn.com
 DOMAIN-SUFFIX,qin.io


### PR DESCRIPTION
## Summary
- Add aiqicha.com, qichacha.com, and qcc.com to Domestic providers.
- Keep Surge, Clash, and Egern provider outputs aligned.

## Why
These are mainland China enterprise lookup services. Without domain rules, fake-ip based clients can miss Domestic IP matching and fall through to FINAL/Proxy.

## Validation
- Confirmed all three domains are present in Surge, Clash, and Egern Domestic providers.
- Parsed Clash/Provider/Domestic.yaml and Egern/Provider/Domestic.yaml with PyYAML.